### PR TITLE
Se corrige el error en el que no se muestra la pantalla de editar perfil

### DIFF
--- a/src/main/java/org/example/ax0006/Manager/SceneManager.java
+++ b/src/main/java/org/example/ax0006/Manager/SceneManager.java
@@ -64,7 +64,7 @@ public class SceneManager {
                 context.getSesion(),
                 context.getProfileService()
         );
-        loadScene("/org/example/ax0006/editProfile.fxml", editProfileController);
+        loadScene("/org/example/ax0006/editprofile.fxml", editProfileController);
     }
 
 


### PR DESCRIPTION
Se corrige la ruta del archivo en la clase de scene manager, esto ayuda que se se corrija el error