### PR TITLE
Agregar pruebas unitarias de integración para módulo financiero

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         run: chmod +x mvnw
 
       - name: Compilar y empaquetar
-        run: ./mvnw --batch-mode -DskipTests package
+        run: mvn --batch-mode -DskipTests package
 
       - name: Ejecutar pruebas automatizadas
-        run: ./mvnw --batch-mode verify
+        run: mvn --batch-mode verify
 
       - name: Generar reporte de resultados de pruebas
         uses: mikepenz/action-junit-report@v5

--- a/src/test/java/org/example/ax0006/service/AnalisisFinancieroServiceTest.java
+++ b/src/test/java/org/example/ax0006/service/AnalisisFinancieroServiceTest.java
@@ -1,0 +1,255 @@
+package org.example.ax0006.service;
+
+import org.example.ax0006.db.H2;
+import org.example.ax0006.entity.AnalisisFinanciero;
+import org.example.ax0006.repository.AnalisisFinancieroRepository;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnalisisFinancieroServiceTest {
+
+    // =========================
+    // ATRIBUTOS
+    // =========================
+    private H2 h2;
+    private AnalisisFinancieroRepository analisisRepo;
+    private AnalisisFinancieroService analisisService;
+
+    // =========================
+    // SETUP
+    // =========================
+    @BeforeEach
+    void prepararEscenario() {
+        h2 = new H2();
+        h2.inicializarDB();
+        analisisRepo = new AnalisisFinancieroRepository(h2);
+        analisisService = new AnalisisFinancieroService(analisisRepo);
+    }
+
+    // =========================
+    // TEARDOWN
+    // =========================
+    @AfterEach
+    void borrarDB() {
+        H2 h2Final = new H2();
+        try (
+                Connection conn = h2Final.getConnection();
+                Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("SET REFERENTIAL_INTEGRITY FALSE");
+            stmt.execute("DROP ALL OBJECTS");
+            stmt.execute("SET REFERENTIAL_INTEGRITY TRUE");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Falló la limpieza de la base de datos.");
+        } finally {
+            h2Final.cerrarServidor();
+        }
+    }
+
+    // =========================
+    // CREAR PRESUPUESTO
+    // =========================
+    @Nested
+    @DisplayName("Crear Presupuesto")
+    class CrearPresupuesto {
+
+        @Test
+        void crearPresupuesto_valorValido_seGuardaEnBD() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            assertTrue(id > 0, "El id generado debe ser mayor a 0");
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af, "El análisis debe existir en BD");
+            assertEquals(5000, af.getPresupuesto());
+            assertFalse(af.isAprobado());
+        }
+
+        @Test
+        void crearPresupuesto_valorCero_noSeGuarda() {
+
+            int id = analisisService.crearPresupuesto(0);
+
+            assertEquals(0, id, "No debe crearse un análisis con presupuesto 0");
+        }
+
+        @Test
+        void crearPresupuesto_valorNegativo_noSeGuarda() {
+
+            int id = analisisService.crearPresupuesto(-100);
+
+            assertEquals(0, id, "No debe crearse un análisis con presupuesto negativo");
+        }
+    }
+
+    // =========================
+    // EDITAR PRESUPUESTO
+    // =========================
+    @Nested
+    @DisplayName("Editar Presupuesto")
+    class EditarPresupuesto {
+
+        @Test
+        void editarPresupuesto_valorValido_seActualizaEnBD() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            analisisService.editarPresupuesto(id, 10000);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertEquals(10000, af.getPresupuesto());
+        }
+
+        @Test
+        void editarPresupuesto_valorCero_noActualiza() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            analisisService.editarPresupuesto(id, 0);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertEquals(5000, af.getPresupuesto(), "El presupuesto no debe cambiar");
+        }
+
+        @Test
+        void editarPresupuesto_valorNegativo_noActualiza() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            analisisService.editarPresupuesto(id, -300);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertEquals(5000, af.getPresupuesto(), "El presupuesto no debe cambiar");
+        }
+    }
+
+    // =========================
+    // APROBAR / DESAPROBAR
+    // =========================
+    @Nested
+    @DisplayName("Aprobar y Desaprobar Presupuesto")
+    class AprobarDesaprobar {
+
+        @Test
+        void aprobarPresupuesto_cambiaAprobadoATrue() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            analisisService.aprobarPresupuesto(id);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertTrue(af.isAprobado());
+        }
+
+        @Test
+        void desaprobarPresupuesto_cambiaAprobadoAFalse() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            analisisService.aprobarPresupuesto(id);
+            analisisService.desaprobarPresupuesto(id);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertFalse(af.isAprobado());
+        }
+    }
+
+    // =========================
+    // OBTENER ANALISIS
+    // =========================
+    @Nested
+    @DisplayName("Obtener Análisis")
+    class ObtenerAnalisis {
+
+        @Test
+        void obtenerAnalisis_existente_retornaAnalisis() {
+
+            int id = analisisService.crearPresupuesto(8000);
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(id);
+
+            assertNotNull(af);
+            assertEquals(id, af.getIdAnalisisF());
+            assertEquals(8000, af.getPresupuesto());
+        }
+
+        @Test
+        void obtenerAnalisis_noExistente_retornaNull() {
+
+            AnalisisFinanciero af = analisisService.obtenerAnalisis(999);
+
+            assertNull(af, "Debe retornar null si no existe");
+        }
+    }
+
+    // =========================
+    // ELIMINAR ANALISIS
+    // =========================
+    @Nested
+    @DisplayName("Eliminar Análisis")
+    class EliminarAnalisis {
+
+        @Test
+        void eliminarAnalisis_existente_noExisteEnBD() {
+
+            int id = analisisService.crearPresupuesto(5000);
+
+            assertNotNull(analisisService.obtenerAnalisis(id));
+
+            analisisService.eliminarAnalisis(id);
+
+            assertNull(
+                    analisisService.obtenerAnalisis(id),
+                    "El análisis debe haberse eliminado de BD"
+            );
+        }
+    }
+
+    // =========================
+    // LISTAR ANALISIS
+    // =========================
+    @Nested
+    @DisplayName("Listar Análisis")
+    class ListarAnalisis {
+
+        @Test
+        void listarAnalisis_variosCreados_retornaTodos() {
+
+            analisisService.crearPresupuesto(1000);
+            analisisService.crearPresupuesto(2000);
+            analisisService.crearPresupuesto(3000);
+
+            List<AnalisisFinanciero> lista =
+                    analisisService.listarAnalisis();
+
+            assertEquals(3, lista.size());
+        }
+
+        @Test
+        void listarAnalisis_sinDatos_retornaVacia() {
+
+            List<AnalisisFinanciero> lista =
+                    analisisService.listarAnalisis();
+
+            assertTrue(lista.isEmpty());
+        }
+    }
+}

--- a/src/test/java/org/example/ax0006/service/BoleteriaServiceTest.java
+++ b/src/test/java/org/example/ax0006/service/BoleteriaServiceTest.java
@@ -1,0 +1,271 @@
+package org.example.ax0006.service;
+
+import org.example.ax0006.db.H2;
+import org.example.ax0006.entity.AnalisisFinanciero;
+import org.example.ax0006.entity.Boleteria;
+import org.example.ax0006.repository.AnalisisFinancieroRepository;
+import org.example.ax0006.repository.BoleteriaRepository;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BoleteriaServiceTest {
+
+    // =========================
+    // ATRIBUTOS
+    // =========================
+    private H2 h2;
+    private BoleteriaRepository boleteriaRepo;
+    private BoleteriaService boleteriaService;
+    private AnalisisFinancieroRepository analisisRepo;
+    private int idAnalisisF;
+
+    // =========================
+    // SETUP
+    // =========================
+    @BeforeEach
+    void prepararEscenario() {
+
+        h2 = new H2();
+        h2.inicializarDB();
+
+        analisisRepo = new AnalisisFinancieroRepository(h2);
+        boleteriaRepo = new BoleteriaRepository(h2);
+        boleteriaService = new BoleteriaService(boleteriaRepo);
+
+        // CREAR ANALISIS BASE para la FK
+        AnalisisFinanciero af = new AnalisisFinanciero();
+        af.setPresupuesto(10000);
+        af.setAprobado(false);
+        idAnalisisF = analisisRepo.guardar(af);
+    }
+
+    // =========================
+    // TEARDOWN
+    // =========================
+    @AfterEach
+    void borrarDB() {
+        H2 h2Final = new H2();
+        try (
+                Connection conn = h2Final.getConnection();
+                Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("SET REFERENTIAL_INTEGRITY FALSE");
+            stmt.execute("DROP ALL OBJECTS");
+            stmt.execute("SET REFERENTIAL_INTEGRITY TRUE");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Falló la limpieza de la base de datos.");
+        } finally {
+            h2Final.cerrarServidor();
+        }
+    }
+
+    // =========================
+    // AGREGAR BOLETERIA
+    // =========================
+    @Nested
+    @DisplayName("Agregar Boletería")
+    class AgregarBoleteria {
+
+        @Test
+        void agregarBoleteria_datosValidos_seGuardaEnBD() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "VIP", 100, 50000, idAnalisisF
+            );
+
+            assertTrue(id > 0, "El id generado debe ser mayor a 0");
+
+            List<Boleteria> lista =
+                    boleteriaService.listarBoleteria(idAnalisisF);
+
+            assertEquals(1, lista.size());
+            assertEquals("VIP", lista.get(0).getSeccion());
+            assertEquals(100, lista.get(0).getCantidad());
+            assertEquals(50000, lista.get(0).getPrecioBoleta());
+            assertEquals(5000000, lista.get(0).getIngresoTotal());
+        }
+
+        @Test
+        void agregarBoleteria_seccionNula_noSeGuarda() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    null, 100, 50000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    boleteriaService.listarBoleteria(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarBoleteria_seccionVacia_noSeGuarda() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "   ", 100, 50000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    boleteriaService.listarBoleteria(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarBoleteria_cantidadCero_noSeGuarda() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "General", 0, 50000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    boleteriaService.listarBoleteria(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarBoleteria_cantidadNegativa_noSeGuarda() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "General", -10, 50000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    boleteriaService.listarBoleteria(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarBoleteria_precioNegativo_noSeGuarda() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "General", 100, -1000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    boleteriaService.listarBoleteria(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarBoleteria_ingresoTotalCalculadoCorrectamente() {
+
+            boleteriaService.agregarBoleteria(
+                    "Palco", 200, 75000, idAnalisisF
+            );
+
+            List<Boleteria> lista =
+                    boleteriaService.listarBoleteria(idAnalisisF);
+
+            assertEquals(1, lista.size());
+            assertEquals(
+                    200 * 75000,
+                    lista.get(0).getIngresoTotal()
+            );
+        }
+    }
+
+    // =========================
+    // ELIMINAR BOLETERIA
+    // =========================
+    @Nested
+    @DisplayName("Eliminar Boletería")
+    class EliminarBoleteria {
+
+        @Test
+        void eliminarBoleteria_existente_noExisteEnBD() {
+
+            int id = boleteriaService.agregarBoleteria(
+                    "General", 50, 30000, idAnalisisF
+            );
+
+            assertTrue(id > 0);
+
+            boleteriaService.eliminarBoleteria(id);
+
+            List<Boleteria> lista =
+                    boleteriaService.listarBoleteria(idAnalisisF);
+
+            assertTrue(lista.isEmpty(), "La boletería debe haberse eliminado");
+        }
+    }
+
+    // =========================
+    // LISTAR BOLETERIA
+    // =========================
+    @Nested
+    @DisplayName("Listar Boletería")
+    class ListarBoleteria {
+
+        @Test
+        void listarBoleteria_variosAgregados_retornaTodos() {
+
+            boleteriaService.agregarBoleteria(
+                    "VIP", 100, 50000, idAnalisisF
+            );
+            boleteriaService.agregarBoleteria(
+                    "General", 200, 20000, idAnalisisF
+            );
+            boleteriaService.agregarBoleteria(
+                    "Palco", 50, 100000, idAnalisisF
+            );
+
+            List<Boleteria> lista =
+                    boleteriaService.listarBoleteria(idAnalisisF);
+
+            assertEquals(3, lista.size());
+        }
+
+        @Test
+        void listarBoleteria_sinDatos_retornaVacia() {
+
+            List<Boleteria> lista =
+                    boleteriaService.listarBoleteria(idAnalisisF);
+
+            assertTrue(lista.isEmpty());
+        }
+    }
+
+    // =========================
+    // TOTAL BOLETERIA
+    // =========================
+    @Nested
+    @DisplayName("Total Boletería")
+    class TotalBoleteria {
+
+        @Test
+        void obtenerTotalBoleteria_variosRegistros_retornaSuma() {
+
+            boleteriaService.agregarBoleteria(
+                    "VIP", 100, 50000, idAnalisisF
+            );
+            boleteriaService.agregarBoleteria(
+                    "General", 200, 20000, idAnalisisF
+            );
+
+            int total = boleteriaService.obtenerTotalBoleteria(idAnalisisF);
+
+            assertEquals(
+                    (100 * 50000) + (200 * 20000),
+                    total
+            );
+        }
+
+        @Test
+        void obtenerTotalBoleteria_sinRegistros_retornaCero() {
+
+            int total = boleteriaService.obtenerTotalBoleteria(idAnalisisF);
+
+            assertEquals(0, total);
+        }
+    }
+}

--- a/src/test/java/org/example/ax0006/service/GastoServiceTest.java
+++ b/src/test/java/org/example/ax0006/service/GastoServiceTest.java
@@ -1,0 +1,236 @@
+package org.example.ax0006.service;
+
+import org.example.ax0006.db.H2;
+import org.example.ax0006.entity.AnalisisFinanciero;
+import org.example.ax0006.entity.Gasto;
+import org.example.ax0006.repository.AnalisisFinancieroRepository;
+import org.example.ax0006.repository.GastoRepository;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GastoServiceTest {
+
+    // =========================
+    // ATRIBUTOS
+    // =========================
+    private H2 h2;
+    private GastoRepository gastoRepo;
+    private GastoService gastoService;
+    private AnalisisFinancieroRepository analisisRepo;
+    private int idAnalisisF;
+
+    // =========================
+    // SETUP
+    // =========================
+    @BeforeEach
+    void prepararEscenario() {
+
+        h2 = new H2();
+        h2.inicializarDB();
+
+        analisisRepo = new AnalisisFinancieroRepository(h2);
+        gastoRepo = new GastoRepository(h2);
+        gastoService = new GastoService(gastoRepo);
+
+        // CREAR ANALISIS BASE para la FK
+        AnalisisFinanciero af = new AnalisisFinanciero();
+        af.setPresupuesto(10000);
+        af.setAprobado(false);
+        idAnalisisF = analisisRepo.guardar(af);
+    }
+
+    // =========================
+    // TEARDOWN
+    // =========================
+    @AfterEach
+    void borrarDB() {
+        H2 h2Final = new H2();
+        try (
+                Connection conn = h2Final.getConnection();
+                Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("SET REFERENTIAL_INTEGRITY FALSE");
+            stmt.execute("DROP ALL OBJECTS");
+            stmt.execute("SET REFERENTIAL_INTEGRITY TRUE");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Falló la limpieza de la base de datos.");
+        } finally {
+            h2Final.cerrarServidor();
+        }
+    }
+
+    // =========================
+    // AGREGAR GASTO
+    // =========================
+    @Nested
+    @DisplayName("Agregar Gasto")
+    class AgregarGasto {
+
+        @Test
+        void agregarGasto_datosValidos_seGuardaEnBD() {
+
+            int id = gastoService.agregarGasto(
+                    "Sonido", 300000, idAnalisisF
+            );
+
+            assertTrue(id > 0, "El id generado debe ser mayor a 0");
+
+            List<Gasto> lista =
+                    gastoService.listarGastos(idAnalisisF);
+
+            assertEquals(1, lista.size());
+            assertEquals("Sonido", lista.get(0).getDescripcion());
+            assertEquals(300000, lista.get(0).getValor());
+        }
+
+        @Test
+        void agregarGasto_descripcionNula_noSeGuarda() {
+
+            int id = gastoService.agregarGasto(
+                    null, 300000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    gastoService.listarGastos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarGasto_descripcionVacia_noSeGuarda() {
+
+            int id = gastoService.agregarGasto(
+                    "   ", 300000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    gastoService.listarGastos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarGasto_valorCero_noSeGuarda() {
+
+            int id = gastoService.agregarGasto(
+                    "Luces", 0, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    gastoService.listarGastos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarGasto_valorNegativo_noSeGuarda() {
+
+            int id = gastoService.agregarGasto(
+                    "Luces", -5000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    gastoService.listarGastos(idAnalisisF).isEmpty()
+            );
+        }
+    }
+
+    // =========================
+    // ELIMINAR GASTO
+    // =========================
+    @Nested
+    @DisplayName("Eliminar Gasto")
+    class EliminarGasto {
+
+        @Test
+        void eliminarGasto_existente_noExisteEnBD() {
+
+            int id = gastoService.agregarGasto(
+                    "Transporte", 150000, idAnalisisF
+            );
+
+            assertTrue(id > 0);
+
+            gastoService.eliminarGasto(id);
+
+            List<Gasto> lista =
+                    gastoService.listarGastos(idAnalisisF);
+
+            assertTrue(lista.isEmpty(), "El gasto debe haberse eliminado");
+        }
+    }
+
+    // =========================
+    // LISTAR GASTOS
+    // =========================
+    @Nested
+    @DisplayName("Listar Gastos")
+    class ListarGastos {
+
+        @Test
+        void listarGastos_variosAgregados_retornaTodos() {
+
+            gastoService.agregarGasto(
+                    "Sonido", 300000, idAnalisisF
+            );
+            gastoService.agregarGasto(
+                    "Luces", 200000, idAnalisisF
+            );
+            gastoService.agregarGasto(
+                    "Transporte", 150000, idAnalisisF
+            );
+
+            List<Gasto> lista =
+                    gastoService.listarGastos(idAnalisisF);
+
+            assertEquals(3, lista.size());
+        }
+
+        @Test
+        void listarGastos_sinDatos_retornaVacia() {
+
+            List<Gasto> lista =
+                    gastoService.listarGastos(idAnalisisF);
+
+            assertTrue(lista.isEmpty());
+        }
+    }
+
+    // =========================
+    // TOTAL GASTOS
+    // =========================
+    @Nested
+    @DisplayName("Total Gastos")
+    class TotalGastos {
+
+        @Test
+        void obtenerTotalGastos_variosRegistros_retornaSuma() {
+
+            gastoService.agregarGasto(
+                    "Sonido", 300000, idAnalisisF
+            );
+            gastoService.agregarGasto(
+                    "Luces", 200000, idAnalisisF
+            );
+
+            int total = gastoService.obtenerTotalGastos(idAnalisisF);
+
+            assertEquals(500000, total);
+        }
+
+        @Test
+        void obtenerTotalGastos_sinRegistros_retornaCero() {
+
+            int total = gastoService.obtenerTotalGastos(idAnalisisF);
+
+            assertEquals(0, total);
+        }
+    }
+}

--- a/src/test/java/org/example/ax0006/service/IngresoServiceTest.java
+++ b/src/test/java/org/example/ax0006/service/IngresoServiceTest.java
@@ -1,0 +1,236 @@
+package org.example.ax0006.service;
+
+import org.example.ax0006.db.H2;
+import org.example.ax0006.entity.AnalisisFinanciero;
+import org.example.ax0006.entity.Ingreso;
+import org.example.ax0006.repository.AnalisisFinancieroRepository;
+import org.example.ax0006.repository.IngresoRepository;
+import org.junit.jupiter.api.*;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IngresoServiceTest {
+
+    // =========================
+    // ATRIBUTOS
+    // =========================
+    private H2 h2;
+    private IngresoRepository ingresoRepo;
+    private IngresoService ingresoService;
+    private AnalisisFinancieroRepository analisisRepo;
+    private int idAnalisisF;
+
+    // =========================
+    // SETUP
+    // =========================
+    @BeforeEach
+    void prepararEscenario() {
+
+        h2 = new H2();
+        h2.inicializarDB();
+
+        analisisRepo = new AnalisisFinancieroRepository(h2);
+        ingresoRepo = new IngresoRepository(h2);
+        ingresoService = new IngresoService(ingresoRepo);
+
+        // CREAR ANALISIS BASE para la FK
+        AnalisisFinanciero af = new AnalisisFinanciero();
+        af.setPresupuesto(10000);
+        af.setAprobado(false);
+        idAnalisisF = analisisRepo.guardar(af);
+    }
+
+    // =========================
+    // TEARDOWN
+    // =========================
+    @AfterEach
+    void borrarDB() {
+        H2 h2Final = new H2();
+        try (
+                Connection conn = h2Final.getConnection();
+                Statement stmt = conn.createStatement()
+        ) {
+            stmt.execute("SET REFERENTIAL_INTEGRITY FALSE");
+            stmt.execute("DROP ALL OBJECTS");
+            stmt.execute("SET REFERENTIAL_INTEGRITY TRUE");
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail("Falló la limpieza de la base de datos.");
+        } finally {
+            h2Final.cerrarServidor();
+        }
+    }
+
+    // =========================
+    // AGREGAR INGRESO
+    // =========================
+    @Nested
+    @DisplayName("Agregar Ingreso")
+    class AgregarIngreso {
+
+        @Test
+        void agregarIngreso_datosValidos_seGuardaEnBD() {
+
+            int id = ingresoService.agregarIngreso(
+                    "Patrocinio Nike", 500000, idAnalisisF
+            );
+
+            assertTrue(id > 0, "El id generado debe ser mayor a 0");
+
+            List<Ingreso> lista =
+                    ingresoService.listarIngresos(idAnalisisF);
+
+            assertEquals(1, lista.size());
+            assertEquals("Patrocinio Nike", lista.get(0).getDescripcion());
+            assertEquals(500000, lista.get(0).getValor());
+        }
+
+        @Test
+        void agregarIngreso_descripcionNula_noSeGuarda() {
+
+            int id = ingresoService.agregarIngreso(
+                    null, 500000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    ingresoService.listarIngresos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarIngreso_descripcionVacia_noSeGuarda() {
+
+            int id = ingresoService.agregarIngreso(
+                    "   ", 500000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    ingresoService.listarIngresos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarIngreso_valorCero_noSeGuarda() {
+
+            int id = ingresoService.agregarIngreso(
+                    "Patrocinio", 0, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    ingresoService.listarIngresos(idAnalisisF).isEmpty()
+            );
+        }
+
+        @Test
+        void agregarIngreso_valorNegativo_noSeGuarda() {
+
+            int id = ingresoService.agregarIngreso(
+                    "Patrocinio", -1000, idAnalisisF
+            );
+
+            assertEquals(0, id);
+            assertTrue(
+                    ingresoService.listarIngresos(idAnalisisF).isEmpty()
+            );
+        }
+    }
+
+    // =========================
+    // ELIMINAR INGRESO
+    // =========================
+    @Nested
+    @DisplayName("Eliminar Ingreso")
+    class EliminarIngreso {
+
+        @Test
+        void eliminarIngreso_existente_noExisteEnBD() {
+
+            int id = ingresoService.agregarIngreso(
+                    "Taquilla", 1000000, idAnalisisF
+            );
+
+            assertTrue(id > 0);
+
+            ingresoService.eliminarIngreso(id);
+
+            List<Ingreso> lista =
+                    ingresoService.listarIngresos(idAnalisisF);
+
+            assertTrue(lista.isEmpty(), "El ingreso debe haberse eliminado");
+        }
+    }
+
+    // =========================
+    // LISTAR INGRESOS
+    // =========================
+    @Nested
+    @DisplayName("Listar Ingresos")
+    class ListarIngresos {
+
+        @Test
+        void listarIngresos_variosAgregados_retornaTodos() {
+
+            ingresoService.agregarIngreso(
+                    "Taquilla", 1000000, idAnalisisF
+            );
+            ingresoService.agregarIngreso(
+                    "Patrocinio", 500000, idAnalisisF
+            );
+            ingresoService.agregarIngreso(
+                    "Merchandising", 200000, idAnalisisF
+            );
+
+            List<Ingreso> lista =
+                    ingresoService.listarIngresos(idAnalisisF);
+
+            assertEquals(3, lista.size());
+        }
+
+        @Test
+        void listarIngresos_sinDatos_retornaVacia() {
+
+            List<Ingreso> lista =
+                    ingresoService.listarIngresos(idAnalisisF);
+
+            assertTrue(lista.isEmpty());
+        }
+    }
+
+    // =========================
+    // TOTAL INGRESOS
+    // =========================
+    @Nested
+    @DisplayName("Total Ingresos")
+    class TotalIngresos {
+
+        @Test
+        void obtenerTotalIngresos_variosRegistros_retornaSuma() {
+
+            ingresoService.agregarIngreso(
+                    "Taquilla", 1000000, idAnalisisF
+            );
+            ingresoService.agregarIngreso(
+                    "Patrocinio", 500000, idAnalisisF
+            );
+
+            int total = ingresoService.obtenerTotalIngresos(idAnalisisF);
+
+            assertEquals(1500000, total);
+        }
+
+        @Test
+        void obtenerTotalIngresos_sinRegistros_retornaCero() {
+
+            int total = ingresoService.obtenerTotalIngresos(idAnalisisF);
+
+            assertEquals(0, total);
+        }
+    }
+}


### PR DESCRIPTION
¿Qué se hizo?
Se agregaron pruebas de integración con H2 en memoria para los servicios del módulo financiero:

AnalisisFinancieroServiceTest — cubre crear, editar, aprobar, desaprobar, obtener, eliminar y listar análisis.
BoleteriaServiceTest — cubre agregar, eliminar, listar y calcular ingreso total de boletería.
IngresoServiceTest — cubre agregar, eliminar, listar y calcular total de ingresos.
GastoServiceTest — cubre agregar, eliminar, listar y calcular total de gastos.

¿Cómo se probó?
Cada test usa una BD H2 real que se inicializa en @BeforeEach y se destruye completamente en @AfterEach, garantizando aislamiento total entre pruebas.